### PR TITLE
Make sure Semigroup maintains prototype of left argument

### DIFF
--- a/src/semigroup/object.js
+++ b/src/semigroup/object.js
@@ -5,7 +5,7 @@ const { keys, assign, getOwnPropertyDescriptor } = Object;
 Semigroup.instance(Object, {
   append(o1, o2) {
     let properties = assign({}, propertiesOf(o1), propertiesOf(o2));
-    return Object.create(Object.prototype, properties);
+    return Object.create(Object.getPrototypeOf(o1), properties);
   }
 });
 

--- a/tests/funcadelic-test.js
+++ b/tests/funcadelic-test.js
@@ -24,6 +24,15 @@ describe('Semigroup', function() {
   it('appends arrays', function() {
     expect(append([1,2,3], [4,4,4])).to.deep.equal([1,2,3,4,4,4]);
   });
+  it('maintains prototype', function() {
+    class OneAndTwo {
+      constructor() {
+        this.one = 1;
+        this.two = 2;
+      }
+    }
+    expect(append(new OneAndTwo(), { two: 'two', three: 3 })).to.be.instanceof(OneAndTwo);
+  });
 });
 
 describe('Monoid', function () {


### PR DESCRIPTION
Added a test and fix to ensure that prototype of left argument is maintained when appending objects.

The fix is only one line change but prettier went nuts on the test.