### PR TITLE
Allow Promise application to run in parallel.

### DIFF
--- a/src/applicative/promise.js
+++ b/src/applicative/promise.js
@@ -5,6 +5,6 @@ Applicative.instance(Promise, {
     return Promise.resolve(value);
   },
   apply(left, right) {
-    return left.then((fn) => right.then(fn));
+    return Promise.all([left, right]).then(([fn, value]) => fn(value));
   }
 });


### PR DESCRIPTION
When applying a function to a list of values, it the arguments are independent of each other, and so there is no need to explicity sequence them.

This allows the two promises to run in parallel and resolve in any order. In practice this won't make much difference, since we're not creating any new promises inside our function application, and _both_ have to be resolved in order to proceed, but at the very least it makes very clear that the evaluation of arguments for function application happens _in parallel_