### PR TITLE
Use normal classes for Typeclasses

### DIFF
--- a/src/applicative.js
+++ b/src/applicative.js
@@ -4,21 +4,23 @@ import { foldl } from './foldable';
 import { type } from './typeclasses';
 import curry from 'lodash/curry';
 
-export const Applicative = type(class Applicative extends Functor {});
+export const Applicative = type(class Applicative extends Functor {
+  pure(Type, value) {
+    return this(Type).pure(value);
+  }
 
-export function pure(Type, value) {
-  return Applicative(Type).pure(value);
-}
+  apply(Type, fn, list) {
+    let applicative = this(Type.prototype);
+    let monoid = Monoid.create(class {
+      empty() {
+        return applicative.pure(curry(fn));
+      }
+      append(left, right) {
+        return applicative.apply(left, right);
+      }
+    });
+    return monoid.reduce(list);
+  }
+});
 
-export function apply(Type, fn, list) {
-  let applicative = Applicative(Type.prototype);
-  let monoid = Monoid.create(class {
-    empty() {
-      return applicative.pure(curry(fn));
-    }
-    append(left, right) {
-      return applicative.apply(left, right);
-    }
-  });
-  return monoid.reduce(list);
-}
+export const { pure, apply } = Applicative.prototype;

--- a/src/filterable.js
+++ b/src/filterable.js
@@ -1,7 +1,9 @@
 import { type } from './typeclasses';
 
-export const Filterable = type(class Filterable {});
+export const Filterable = type(class Filterable {
+  filter(fn, f) {
+    return this(f).filter(fn, f);
+  }
+});
 
-export function filter(fn, f) {
-  return Filterable(f).filter(fn, f);
-}
+export const { filter } = Filterable.prototype;

--- a/src/foldable.js
+++ b/src/foldable.js
@@ -1,18 +1,20 @@
 import { type } from './typeclasses';
 
-export const Foldable = type(class Foldable {});
+export const Foldable = type(class Foldable {
+  foldr(fn, initial, foldable) {
+    let { foldr } = this(foldable);
+    return foldr(fn, initial, foldable);
+  }
 
-export function foldr(fn, initial, foldable) {
-  let { foldr } = Foldable(foldable);
-  return foldr(fn, initial, foldable);
-}
+  foldl(fn, initial, foldable) {
+    let { foldl } = this(foldable);
+    return foldl(fn, initial, foldable);
+  }
 
-export function foldl(fn, initial, foldable) {
-  let { foldl } = Foldable(foldable);
-  return foldl(fn, initial, foldable);
-}
+  size(foldable) {
+    let { foldr } = this(foldable);
+    return foldr((len) => len + 1, 0, foldable);
+  }
+});
 
-export function length(foldable) {
-  let { foldr } = Foldable(foldable);
-  return foldr((len) => len + 1, 0, foldable);
-}
+export const { foldr, foldl, size } = Foldable.prototype;

--- a/src/functor.js
+++ b/src/functor.js
@@ -1,8 +1,10 @@
 import { type } from './typeclasses';
 
-export const Functor = type(class Functor {});
+export const Functor = type(class Functor {
+  map(fn, f) {
+    let { map } = this(f);
+    return map(fn, f);
+  }
+});
 
-export function map(fn, f) {
-  let { map } = Functor(f);
-  return map(fn, f);
-}
+export const { map } = Functor.prototype;

--- a/src/monoid.js
+++ b/src/monoid.js
@@ -3,12 +3,12 @@ import { foldl } from './foldable';
 import { map } from './functor';
 import { type } from './typeclasses';
 
-export const Monoid = type(class Monoid extends Semigroup {});
-
-export function reduce(M, values) {
-  let empty = Monoid(M.prototype).empty();
-  return foldl((reduction, value) => append(reduction, value), empty, values);
-}
+export const Monoid = type(class Monoid extends Semigroup {
+  reduce(M, values) {
+    let empty = this(M.prototype).empty();
+    return foldl((reduction, value) => append(reduction, value), empty, values);
+  }
+});
 
 Monoid.create = function create(Definition) {
   class Monoidal extends Definition {
@@ -30,3 +30,5 @@ Monoid.create = function create(Definition) {
   });
   return Monoidal;
 };
+
+export const { reduce } = Monoid.prototype;

--- a/src/semigroup.js
+++ b/src/semigroup.js
@@ -1,8 +1,10 @@
 import { type } from './typeclasses';
 
-export const Semigroup = type(class Semigroup {});
+export const Semigroup = type(class Semigroup {
+  append(left, right) {
+    let { append } = this(left);
+    return append(left, right);
+  }
+});
 
-export function append(left, right) {
-  let { append } = Semigroup(left);
-  return append(left, right);
-}
+export const { append } = Semigroup.prototype;

--- a/src/typeclasses.js
+++ b/src/typeclasses.js
@@ -1,3 +1,5 @@
+const { assign, keys, getOwnPropertyDescriptors } = Object;
+
 export function type(Class) {
 
   let name = Class.name;
@@ -8,7 +10,7 @@ export function type(Class) {
 
   let symbol = Symbol(name);
 
-  function getTypeclassInstanceForValue(value) {
+  Class.for = function _for(value) {
     let i = value[symbol];
     if (!i) {
       throw new Error(`No instance found on ${value} of typeclass ${name}`);
@@ -16,12 +18,16 @@ export function type(Class) {
     return i;
   };
 
-  getTypeclassInstanceForValue.instance = function(constructor, impl) {
-    constructor.prototype[symbol] = impl;
+  Class.instance = function(constructor, methods) {
+    constructor.prototype[symbol] = methods;
   };
 
-  getTypeclassInstanceForValue.symbol = symbol;
+  Class.symbol = symbol;
 
+  let properties = getOwnPropertyDescriptors(Class.prototype);
+  keys(properties).filter(key => key != 'constructor').forEach(key => {
+    Class.prototype[key] = Class.prototype[key].bind(Class.for);
+  });
 
-  return getTypeclassInstanceForValue;
+  return Class;
 }


### PR DESCRIPTION
Funcadelic was using a kinda odd-ball mechanism to define typeclasses. This was so that you could use the typeclass name as a function to get the typeclass instance:

```javascript
Functor([]).map //=> gets the `map` method off of the specific
instance of Functor
```

While this is kind of clever, it turns out that you don't really ever need to get the instance except inside of the delegate, so it isn't really worth it.

This change puts all of the dispatch functions right on the class itself, and doesn't create a wrapper of any kind.

Inside typeclass methods, the typeclass instance can be accessed by calling the `this()` function. E.g.

```javascript
export const Functor = type(class Functor {
  map(fn, f) {
    let { map } = this(f);
    return map(fn, f);
  }
});
```

If you're outside of the typeclass declaration itself, then you can access the instance with the `.for()` method. E.g.

```javascript
let array = [1,2];
Functor.for(array).map(x => x * 2, array) //=> [2,4]
```

But this should be very rare indeed.