### PR TITLE
Polyfill getOwnPropertyDescriptors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
 node_js:
+  - "9"
   - "8"
+  - "7"
+  - "6"

--- a/src/typeclasses.js
+++ b/src/typeclasses.js
@@ -1,4 +1,5 @@
-const { assign, keys, getOwnPropertyDescriptors } = Object;
+import getOwnPropertyDescriptors from 'object.getownpropertydescriptors';
+const { assign, keys } = Object;
 
 export function type(Class) {
 


### PR DESCRIPTION
Node 6 doesn't support `Object.getOwnPropertyDescriptors`, so funcadelic can't be used there.

Instead of pulling off the function from `Object`, pull it in from `object.getownpropertydescriptors`

At the same time, fill in the matrix of node environments to include from 6-9