### PR TITLE
Disambiguate applicative instance apply and applyOne()

### DIFF
--- a/src/applicative.js
+++ b/src/applicative.js
@@ -1,4 +1,3 @@
-import { Monoid } from './monoid';
 import { Functor } from './functor';
 import { foldl } from './foldable';
 import { type } from './typeclasses';
@@ -10,17 +9,14 @@ export const Applicative = type(class Applicative extends Functor {
   }
 
   apply(Type, fn, list) {
-    let applicative = this(Type.prototype);
-    let monoid = Monoid.create(class {
-      empty() {
-        return applicative.pure(curry(fn));
-      }
-      append(left, right) {
-        return applicative.apply(left, right);
-      }
-    });
-    return monoid.reduce(list);
+    let { pure, applyOne } = this(Type.prototype);
+    let initial = pure(curry(fn));
+    return foldl((left, right) => applyOne(left, right), initial, list);
+  }
+
+  applyOne(left, right) {
+    this(left).applyOne(right);
   }
 });
 
-export const { pure, apply } = Applicative.prototype;
+export const { pure, apply, applyOne } = Applicative.prototype;

--- a/src/applicative/promise.js
+++ b/src/applicative/promise.js
@@ -4,7 +4,7 @@ Applicative.instance(Promise, {
   pure(value) {
     return Promise.resolve(value);
   },
-  apply(left, right) {
+  applyOne(left, right) {
     return Promise.all([left, right]).then(([fn, value]) => fn(value));
   }
 });


### PR DESCRIPTION
Previously, the Applicative instance was expected to have a method call `apply` that only applied a function to a single value. It then had a global function `apply` that utilized the instance `apply` to reduce an entire list one value at a time. That worked as long as there weren't any recursive values, but when you need to call back into the "single" value `apply` the names get confusing.

This separates out the single function that only appends two values together via function application. So the minimal implementation of applicative is now `applyOne`, and `apply` is what you call when you want to reduce a list of values via function application.

It also removes the monoid from the definition of `apply()`. While the application itself is in fact a monoid, it didn't lend any clarity to the code and so it has been changed to be a simple `foldl`.