### PR TITLE
Maintain prototype in filter

### DIFF
--- a/src/filterable/object.js
+++ b/src/filterable/object.js
@@ -2,8 +2,11 @@ import { Filterable } from '../filterable';
 import { foldr } from '../foldable';
 import { append } from '../semigroup';
 
+const { create, getPrototypeOf } = Object;
+
 Filterable.instance(Object, {
   filter(fn, object) {
+    let instance = create(getPrototypeOf(object));
     return foldr((filtered, entry) => {
       if (fn(entry)) {
         return append(filtered, {
@@ -12,6 +15,6 @@ Filterable.instance(Object, {
       } else {
         return filtered;
       }
-    }, {}, object);
+    }, instance, object);
   }
 });

--- a/tests/funcadelic-test.js
+++ b/tests/funcadelic-test.js
@@ -89,6 +89,10 @@ describe('Filterable', function() {
     expect(filter(({key}) => key !== 'nope', {yes: 1, yep: 2, nope: 3, yup: 4}))
       .to.deep.equal({yes: 1, yep: 2, yup: 4});
   });
+  it('preserves prototype', function() {
+    class MyClass {}
+    expect(filter(memo => memo, new MyClass())).to.be.instanceOf(MyClass);
+  });
 });
 
 


### PR DESCRIPTION
I needed a way to map an immutable instance - so I ended up using `map` but in the process I found that filter changes class instances into objects. This PR maintains prototype of instances when applying filter to them.

Dunno if this is right, but you decide.