### PR TITLE
Make resulting values of an object map stable.

### DIFF
--- a/src/functor/object.js
+++ b/src/functor/object.js
@@ -1,6 +1,7 @@
 import { Functor } from '../functor';
 import { append } from '../semigroup';
 import { foldr } from '../foldable';
+import stable from '../stable';
 
 const { assign, keys, getPrototypeOf } = Object;
 
@@ -10,9 +11,7 @@ Functor.instance(Object, {
       return append(properties, {
         [entry.key]: {
           enumerable: true,
-          get() {
-            return fn(entry.value, entry.key);
-          }
+          get: stable(() => fn(entry.value, entry.key))
         }
       });
     }, {}, object);

--- a/src/stable.js
+++ b/src/stable.js
@@ -1,0 +1,22 @@
+export default function stable(fn) {
+  switch (fn.length) {
+  case 0:
+    return thunk(fn);
+  default:
+    throw new Error('Cannot (yet) make functions with arguments stable');
+  }
+}
+
+function thunk(fn) {
+  let evaluated = false;
+  let result = undefined;
+  return function evaluate() {
+    if (evaluated) {
+      return result;
+    } else {
+      result = fn();
+      evaluated = true;
+      return result;
+    }
+  };
+}

--- a/tests/funcadelic-test.js
+++ b/tests/funcadelic-test.js
@@ -19,6 +19,10 @@ describe('Functor', function() {
   it('maps objects', function() {
     expect(map((i) => i * 2, {one: 1, two: 2})).to.deep.equal({one: 2, two: 4});
   });
+  it('maps objects, and maintains stability over its values.', function() {
+    let objects =  map(i => ({}), {one: 1, two: 2});
+    expect(objects.one).to.equal(objects.one);
+  });
   it('maps arrays', function() {
     expect(map(i => i * 2, [1, 2, 3])).to.deep.equal([2,4,6]);
   });


### PR DESCRIPTION
When you map an object like

```js
let mapped = map(x => x * 2, {one: 1, two: 2});
```

Because of the way that object map is implemented, every time you access the properties of mapped, the mapping function will be excuted every single time. For example:

```js
mapped.one
mapped.one
mapped.one
```

Will execute `x => x * 2` three times. But mapping is a pure function and so the answer can _never_ change between these three mappings, so it's pointless to execute it more than once. This is annoying not only from the perspective of computational work, but also from the perspective of referential transparency. In other words, if my mapping function is pure, it should return the same value every time, even if that is a reference value like `Object` or `Array`

What we'd like to do instead is only execute the mapping function once, and then store the result in case it's ever needed again.

This introduces a `stable` module which allows you to create functions that memoize their results which is then used by the getter inside the `Object` Functor instance to stabliize the value of each key.

### Open Questions / Avenues for Exploration

- This will change the memory profile of object maps, and once calculated, whatever is returned by the mapping function will be held onto so long as the object itself is held onto. So in the above example `mapped.one` cannot be garbage collected until `mapped` is garbage collected. This should not be a problem since in effect what's happening is `mapped.one` is just like a normal property once evaluated.

- Currently, the only functions that can be stableized are those with zero arguments, but we have a proof of concept for a general mechanism for stableizing functions of 1, 2, 3, and 4 arguments.