### PR TITLE
Wrapping getters in thunk in append

### DIFF
--- a/src/semigroup/object.js
+++ b/src/semigroup/object.js
@@ -1,6 +1,6 @@
 import { Semigroup } from '../semigroup';
 import propertiesOf from 'object.getownpropertydescriptors';
-import stable, { Stable } from '../stable';
+import stable from '../stable';
 
 const { assign, getPrototypeOf, keys } = Object;
 
@@ -14,7 +14,7 @@ Semigroup.instance(Object, {
 function cacheGetters(descriptors) {
   return keys(descriptors).reduce(function(memo, key) {
     let descriptor = descriptors[key];
-    if (descriptor.get && descriptor.get[Stable] || !descriptor.get) {
+    if (!descriptor.get) {
       return assign({}, memo, {
         [key]: descriptor
       });

--- a/src/semigroup/object.js
+++ b/src/semigroup/object.js
@@ -11,7 +11,7 @@ Semigroup.instance(Object, {
   }
 });
 
-export function cacheGetters(descriptors) {
+function cacheGetters(descriptors) {
   return keys(descriptors).reduce(function(memo, key) {
     let descriptor = descriptors[key];
     if (descriptor.get && descriptor.get[Stable] || !descriptor.get) {

--- a/src/semigroup/object.js
+++ b/src/semigroup/object.js
@@ -1,11 +1,12 @@
 import { Semigroup } from '../semigroup';
 import propertiesOf from 'object.getownpropertydescriptors';
+import { cacheGetters } from '../stable';
 
-const { assign, getPrototypeOf } = Object;
+const { assign, getPrototypeOf, keys } = Object;
 
 Semigroup.instance(Object, {
   append(o1, o2) {
-    let properties = assign({}, propertiesOf(o1), propertiesOf(o2));
+    let properties = assign({}, propertiesOf(o1), cacheGetters(propertiesOf(o2)));
     return Object.create(getPrototypeOf(o1), properties);
   }
 });

--- a/src/semigroup/object.js
+++ b/src/semigroup/object.js
@@ -1,12 +1,29 @@
 import { Semigroup } from '../semigroup';
 import propertiesOf from 'object.getownpropertydescriptors';
-import { cacheGetters } from '../stable';
+import stable, { Stable } from '../stable';
 
 const { assign, getPrototypeOf, keys } = Object;
 
 Semigroup.instance(Object, {
   append(o1, o2) {
-    let properties = assign({}, propertiesOf(o1), cacheGetters(propertiesOf(o2)));
-    return Object.create(getPrototypeOf(o1), properties);
+    let properties = assign({}, propertiesOf(o1), propertiesOf(o2));
+    return Object.create(getPrototypeOf(o1), cacheGetters(properties));
   }
 });
+
+export function cacheGetters(descriptors) {
+  return keys(descriptors).reduce(function(memo, key) {
+    let descriptor = descriptors[key];
+    if (descriptor.get && descriptor.get[Stable] || !descriptor.get) {
+      return assign({}, memo, {
+        [key]: descriptor
+      });
+    } else {
+      return assign(memo, {
+        [key]: assign({}, descriptor, {
+          get: stable(descriptor.get)
+        }),
+      });
+    }
+  }, {});
+}

--- a/src/stable.js
+++ b/src/stable.js
@@ -1,4 +1,4 @@
-export const Stable = Symbol('Stable');
+const Stable = Symbol('Stable');
 
 export default function stable(fn) {
   switch (fn.length) {

--- a/src/stable.js
+++ b/src/stable.js
@@ -1,3 +1,5 @@
+const { keys, assign } = Object;
+
 export default function stable(fn) {
   switch (fn.length) {
   case 0:
@@ -14,9 +16,20 @@ function thunk(fn) {
     if (evaluated) {
       return result;
     } else {
-      result = fn();
+      result = fn.call(this);
       evaluated = true;
       return result;
     }
   };
+}
+
+export function cacheGetters(descriptors) {
+  return keys(descriptors).reduce(function(memo, key) {
+    let descriptor = descriptors[key];
+    return assign(memo, {
+      [key]: descriptor.get ? assign(descriptor, {
+        get: stable(descriptor.get)
+      }) : descriptor
+    });
+  }, {});
 }

--- a/src/stable.js
+++ b/src/stable.js
@@ -10,6 +10,9 @@ export default function stable(fn) {
 }
 
 function thunk(fn) {
+  if (fn[Stable]) {
+    return fn;
+  }
   let evaluated = false;
   let result = undefined;
   function evaluate() {

--- a/src/stable.js
+++ b/src/stable.js
@@ -1,4 +1,4 @@
-const { keys, assign } = Object;
+export const Stable = Symbol('Stable');
 
 export default function stable(fn) {
   switch (fn.length) {
@@ -12,7 +12,7 @@ export default function stable(fn) {
 function thunk(fn) {
   let evaluated = false;
   let result = undefined;
-  return function evaluate() {
+  function evaluate() {
     if (evaluated) {
       return result;
     } else {
@@ -21,15 +21,6 @@ function thunk(fn) {
       return result;
     }
   };
-}
-
-export function cacheGetters(descriptors) {
-  return keys(descriptors).reduce(function(memo, key) {
-    let descriptor = descriptors[key];
-    return assign(memo, {
-      [key]: descriptor.get ? assign(descriptor, {
-        get: stable(descriptor.get)
-      }) : descriptor
-    });
-  }, {});
+  evaluate[Stable] = true;
+  return evaluate;
 }

--- a/tests/funcadelic-test.js
+++ b/tests/funcadelic-test.js
@@ -52,6 +52,20 @@ describe('Semigroup', function() {
     }
     expect(append(new OneAndTwo(), { two: 'two', three: 3 })).to.be.instanceof(OneAndTwo);
   });
+  it('caches getters', () => {
+    let called = 0;
+    let result = append({ two: 2, three: 3 }, {
+      get sum() {
+        called++;
+        return this.two + this.three;
+      }
+    });
+
+    expect(result.sum).to.equal(5);
+
+    result.sum; // if getter is not cached, this will cause the counter to be incremented;
+    expect(called).to.equal(1);
+  });
 });
 
 describe('Monoid', function () {

--- a/tests/funcadelic-test.js
+++ b/tests/funcadelic-test.js
@@ -1,5 +1,5 @@
 import { apply, map, append, foldr, foldl, filter, pure, reduce, Monoid, Functor, type } from '../src/funcadelic';
-import stable, { Stable } from '../src/stable';
+import stable from '../src/stable';
 
 import chai  from 'chai';
 import mocha from 'mocha';

--- a/tests/funcadelic-test.js
+++ b/tests/funcadelic-test.js
@@ -147,7 +147,8 @@ describe('A Typeclass', function () {
 });
 
 describe('stable function', () => {
-  it('has Stable symbol', () => {
-    expect(stable(() => {})[Stable]).to.be.true;
+  let stabilized = stable(() => {});
+  it('returns stabilized function when attempting to wrapped previously stabilized function', () => {
+    expect(stable(stabilized)).to.equal(stabilized);
   });
 });

--- a/tests/funcadelic-test.js
+++ b/tests/funcadelic-test.js
@@ -1,4 +1,6 @@
 import { apply, map, append, foldr, foldl, filter, pure, reduce, Monoid, Functor, type } from '../src/funcadelic';
+import stable, { Stable } from '../src/stable';
+
 import chai  from 'chai';
 import mocha from 'mocha';
 
@@ -52,19 +54,24 @@ describe('Semigroup', function() {
     }
     expect(append(new OneAndTwo(), { two: 'two', three: 3 })).to.be.instanceof(OneAndTwo);
   });
-  it('caches getters', () => {
-    let called = 0;
+  it('stabilizes getters on appended object', () => {
     let result = append({ two: 2, three: 3 }, {
       get sum() {
-        called++;
-        return this.two + this.three;
+        return new Number(this.two + this.three);
       }
     });
 
-    expect(result.sum).to.equal(5);
+    expect(result.sum).to.equal(result.sum);
+  });
 
-    result.sum; // if getter is not cached, this will cause the counter to be incremented;
-    expect(called).to.equal(1);
+  it('stabilizes getters on initial object', () => {
+    let result = append({
+      get sum() {
+        return new Number(this.two + this.three);
+      }
+    }, { two: 2, three: 3 });
+
+    expect(result.sum).to.equal(result.sum);
   });
 });
 
@@ -136,5 +143,11 @@ describe('A Typeclass', function () {
   it('has an associated symbol', function() {
     expect(Functor.symbol).not.to.be.undefined;
     expect(Object.getOwnPropertySymbols(Object.prototype)).to.include(Functor.symbol);
+  });
+});
+
+describe('stable function', () => {
+  it('has Stable symbol', () => {
+    expect(stable(() => {})[Stable]).to.be.true;
   });
 });


### PR DESCRIPTION
This PR introduces caching to getters that are added to objects using `append`. 

```js
let combined = append({ two: 2, three: 3 }, {
  get sum() {
    return new Number(this.two + this.three);
  }
});

combined.sum.valueOf() // => 5;
combined.sum === combined.sum
```

The sum calculation will only ever be performed once for any instance. All future invocations will produce previously computed value.

Note: this PR only caches the getters from the second argument.

Related to https://github.com/microstates/microstates.js/pull/81