### PR TITLE
Make sure UMD build is ES5

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "dist"
   ],
   "dependencies": {
+    "babel-plugin-external-helpers": "6.22.0",
     "lodash.curry": "4.1.1",
     "object.getownpropertydescriptors": "2.0.3"
   },
@@ -31,6 +32,7 @@
     "chai": "^4.1.2",
     "mocha": "^3.5.3",
     "rollup": "0.55.1",
+    "rollup-plugin-babel": "3.0.3",
     "rollup-plugin-commonjs": "8.3.0",
     "rollup-plugin-node-resolve": "3.0.2"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,15 @@
+
+import babel from 'rollup-plugin-babel';
 import resolve from 'rollup-plugin-node-resolve'
 import commonjs from 'rollup-plugin-commonjs'
 import pkg from './package.json'
+
+const globals = {
+  'lodash.curry': '_.curry',
+  'object.getownpropertydescriptors': 'Object.getOwnPropertyDescriptors'
+};
+
+let external = Object.keys(globals);
 
 export default [
   // browser-friendly UMD build
@@ -9,17 +18,32 @@ export default [
     output: {
       name: 'funcadelic',
       file: pkg.browser,
+      globals,
       format: 'umd'
     },
-    plugins: [
+    external,
+    plugins: [            
+      babel({
+        runtimeHelpers: true,
+        babelrc: false,
+        comments: false,
+        presets: [
+          [
+            "env",
+            {
+              modules: false
+            }
+          ]
+        ],
+        plugins: ["external-helpers"]
+      }),
       resolve(), 
-      commonjs() 
+      commonjs()
     ]
   },
-
   {
     input: 'src/funcadelic.js',
-    external: id => /lodash/.test(id) || /object.getownpropertydescriptors/.test(id),
+    external,
     output: [
 			{ file: pkg.main, format: 'cjs' }, 
 			{ file: pkg.module, format: 'es' }


### PR DESCRIPTION
Our UMD package includes ES6 features which breaks in IE11. This PR will change our UMD package to ES5.