### PR TITLE
Fix copying symbols

### DIFF
--- a/src/foldable/object.js
+++ b/src/foldable/object.js
@@ -1,5 +1,6 @@
 import { Foldable } from '../foldable';
 
+const { keys } = Object;
 
 Foldable.instance(Object, {
   foldr(fn, initial, object) {
@@ -14,7 +15,3 @@ Foldable.instance(Object, {
     ), initial);
   }
 });
-
-function keys(object) {
-  return [].concat(Object.keys(object), Object.getOwnPropertySymbols(object));
-}

--- a/src/foldable/object.js
+++ b/src/foldable/object.js
@@ -1,6 +1,5 @@
 import { Foldable } from '../foldable';
 
-const { keys } = Object;
 
 Foldable.instance(Object, {
   foldr(fn, initial, object) {
@@ -15,3 +14,7 @@ Foldable.instance(Object, {
     ), initial);
   }
 });
+
+function keys(object) {
+  return [].concat(Object.keys(object), Object.getOwnPropertySymbols(object));
+}

--- a/src/semigroup/object.js
+++ b/src/semigroup/object.js
@@ -3,7 +3,7 @@ import { foldl } from '../foldable';
 import propertiesOf from 'object.getownpropertydescriptors';
 import stable from '../stable';
 
-const { assign, getPrototypeOf } = Object;
+const { assign, getPrototypeOf, getOwnPropertySymbols, keys } = Object;
 
 Semigroup.instance(Object, {
   append(o1, o2) {
@@ -22,7 +22,8 @@ Semigroup.instance(Object, {
  * stableized so that it returns the same value every time.
  */
 function stableize(properties) {
-  return foldl((descriptors, { key, value: descriptor }) => {
+  return foldl((descriptors, key) => {
+    let descriptor = properties[key];
     if (!descriptor.get) {
       return assign({}, descriptors, {
         [key]: descriptor
@@ -34,5 +35,5 @@ function stableize(properties) {
         })
       });
     }
-  }, {}, properties);
+  }, {}, keys(properties).concat(getOwnPropertySymbols(properties)));
 }

--- a/tests/funcadelic-test.js
+++ b/tests/funcadelic-test.js
@@ -63,7 +63,6 @@ describe('Semigroup', function() {
 
     expect(result.sum).to.equal(result.sum);
   });
-
   it('stabilizes getters on initial object', () => {
     let result = append({
       get sum() {
@@ -72,6 +71,19 @@ describe('Semigroup', function() {
     }, { two: 2, three: 3 });
 
     expect(result.sum).to.equal(result.sum);
+  });
+  it('includes symbols', () => {
+    let symbol = Symbol();
+    let obj = {
+      [symbol]: true
+    };
+    let result = append(obj, {});
+
+    expect(obj[symbol]).to.equal(true);
+    expect(Object.getOwnPropertySymbols(obj)).to.deep.equal([symbol]);
+
+    expect(Object.getOwnPropertySymbols(result)).to.equal([symbol]);
+    expect(result[symbol]).to.equal(true);
   });
 });
 

--- a/tests/funcadelic-test.js
+++ b/tests/funcadelic-test.js
@@ -82,7 +82,7 @@ describe('Semigroup', function() {
     expect(obj[symbol]).to.equal(true);
     expect(Object.getOwnPropertySymbols(obj)).to.deep.equal([symbol]);
 
-    expect(Object.getOwnPropertySymbols(result)).to.equal([symbol]);
+    expect(Object.getOwnPropertySymbols(result)).to.deep.equal([symbol]);
     expect(result[symbol]).to.equal(true);
   });
 });


### PR DESCRIPTION
The stabilized getters PR introduced a regression that caused enumerable symbol properties to not be included when appending. This PR corrects the implementation of append to include symbol property descriptors.

Remerging #23 