### PR TITLE
We thunk about it and realized that getters should be cached by instance

### DIFF
--- a/src/semigroup/object.js
+++ b/src/semigroup/object.js
@@ -31,9 +31,16 @@ function stableize(properties) {
     } else {
       return assign({}, descriptors, {
         [key]: assign({}, descriptor, {
-          get: stable(descriptor.get)
+          get: stabilizeGetter(descriptor.get)
         })
       });
     }
   }, {}, keys(properties).concat(getOwnPropertySymbols(properties)));
+}
+
+function stabilizeGetter(fn) {
+  let cached = stable(instance => fn.call(instance));
+  return function bound() {
+    return cached(this);
+  }
 }

--- a/src/semigroup/object.js
+++ b/src/semigroup/object.js
@@ -29,18 +29,14 @@ function stableize(properties) {
         [key]: descriptor
       });
     } else {
+      let cached = stable(instance => descriptor.get.call(instance));
       return assign({}, descriptors, {
         [key]: assign({}, descriptor, {
-          get: stabilizeGetter(descriptor.get)
+          get() {
+            return cached(this);
+          }
         })
       });
     }
   }, {}, keys(properties).concat(getOwnPropertySymbols(properties)));
-}
-
-function stabilizeGetter(fn) {
-  let cached = stable(instance => fn.call(instance));
-  return function bound() {
-    return cached(this);
-  }
 }

--- a/src/stable.js
+++ b/src/stable.js
@@ -4,12 +4,14 @@ export default function stable(fn) {
   switch (fn.length) {
   case 0:
     return thunk(fn);
+  case 1:
+    return stableOne(fn);
   default:
-    throw new Error('Cannot (yet) make functions with arguments stable');
+    throw new Error(`Cannot (yet) make functions with ${fn.length} stable`);
   }
 }
 
-function thunk(fn) {
+export function thunk(fn) {
   if (fn[Stable]) {
     return fn;
   }
@@ -26,4 +28,24 @@ function thunk(fn) {
   };
   evaluate[Stable] = true;
   return evaluate;
+}
+
+export function stableOne(fn) {
+  if (fn[Stable]) {
+    return fn;
+  }
+  let cache = new WeakMap();
+  function stabilizedOne(argument) {
+    if (cache.has(argument)) {
+      return cache.get(argument);
+    } else {
+      let result = fn(argument);
+      cache.set(argument, result);
+      return result;
+    };
+  };
+
+  stabilizedOne[Stable] = true;
+
+  return stabilizedOne;
 }

--- a/src/stable.js
+++ b/src/stable.js
@@ -36,13 +36,10 @@ export function stableOne(fn) {
   }
   let cache = new WeakMap();
   function stabilizedOne(argument) {
-    if (cache.has(argument)) {
-      return cache.get(argument);
-    } else {
-      let result = fn(argument);
-      cache.set(argument, result);
-      return result;
-    };
+    if (!cache.has(argument)) {
+      cache.set(argument, fn(argument));
+    }
+    return cache.get(argument);
   };
 
   stabilizedOne[Stable] = true;


### PR DESCRIPTION
This fixes the current release of funcadelic which we merged and released today. 10 minutes after we published, we realized that getters should be cached by instance rather than per getter. This PR corrects the wrongs of our ways.