### PR TITLE
Benchmark setup

### DIFF
--- a/benchmarks/append.js
+++ b/benchmarks/append.js
@@ -1,0 +1,26 @@
+const Benchmark = require("benchmark");
+const { append } = require("../dist/funcadelic.cjs");
+
+module.exports = new Benchmark.Suite()
+  .add("append", () => {
+    class Person {}
+    for (let i = 0; i < 1000; i++) {
+      append(new Person(), { firstName: 'Foo', lastName: 'Bar' });
+    }
+  })
+  .add("assign", () => {
+    class Person {}
+    for (let i = 0; i < 1000; i++) {
+      Object.assign(new Person(), { firstName: 'Foo', lastName: 'Bar' });
+    }
+  })
+  .add("for in", () => {
+    class Person {}
+    for (let i = 0; i < 1000; i++) {
+      let person = new Person();
+      let props = { firstName: 'Foo', lastName: 'Bar' };
+      for (let prop in props) {
+        person[prop] = props[prop];
+      }
+    }
+  })

--- a/benchmarks/object-append.js
+++ b/benchmarks/object-append.js
@@ -1,4 +1,5 @@
 const Benchmark = require("benchmark");
+
 const { append } = require("../dist/funcadelic.cjs");
 
 module.exports = new Benchmark.Suite()

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "private": false,
   "scripts": {
     "build": "rollup --config",
+    "bench:append": "node ./scripts/bench append",
     "lint": "eslint src",
     "pretest": "npm run build && npm run lint",
     "test": "jest",
@@ -31,9 +32,12 @@
     "@babel/preset-env": "^7.0.0-beta.44",
     "babel-core": "^7.0.0-0",
     "babel-jest": "22.4.3",
+    "benchmark": "2.1.4",
+    "cli-table2": "0.2.0",
     "eslint": "4.19.1",
     "eslint-plugin-prefer-let": "1.0.1",
     "jest": "22.4.3",
+    "ora": "2.0.0",
     "regenerator-runtime": "0.11.1",
     "rollup": "0.57.1",
     "rollup-plugin-babel": "4.0.0-beta.3",
@@ -45,7 +49,7 @@
       "js",
       "json"
     ],
-    "globalSetup": "./build.js",
+    "globalSetup": "./scripts/build.js",
     "modulePaths": [
       "<rootDir>/src",
       "<rootDir>/node_modules"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "private": false,
   "scripts": {
     "build": "rollup --config",
-    "bench:append": "node ./scripts/bench append",
+    "bench": "node ./scripts/bench",
     "lint": "eslint src",
     "pretest": "npm run build && npm run lint",
     "test": "jest",
@@ -34,6 +34,7 @@
     "babel-jest": "22.4.3",
     "benchmark": "2.1.4",
     "cli-table2": "0.2.0",
+    "colors": "1.2.1",
     "eslint": "4.19.1",
     "eslint-plugin-prefer-let": "1.0.1",
     "jest": "22.4.3",

--- a/scripts/bench.js
+++ b/scripts/bench.js
@@ -1,13 +1,14 @@
 const ora = require("ora");
 const Table = require("cli-table2");
+const colors = require('colors');
 
-const suites = {
-  append: require("../benchmarks/append")
-}
+const error = (msg, ...args) => console.log(colors.red(msg), ...args) // eslint-disable-line
+const warn = (msg, ...args) => console.log(colors.yellow(msg), ...args) // eslint-disable-line
+const info = (msg, ...args) => console.log(colors.cyan(msg), ...args) // eslint-disable-line
 
-const spinner = ora("Running benchmark");
+function showResults(name, benchmarkResults) {
+  info(`Results for ${name}`);
 
-function showResults(benchmarkResults) {
   let table = new Table({
     head: ["NAME", "OPS/SEC", "RELATIVE MARGIN OF ERROR", "SAMPLE SIZE"]
   });
@@ -28,20 +29,29 @@ function sortDescResults (benchmarkResults) {
   return benchmarkResults.sort((a, b) => a.target.hz < b.target.hz ? 1 : -1)
 }
 
-function run(suite) {
+function run(name) {
   let benchmarkResults = [];
+  let suite = require(`../benchmarks/${name}`);
+  let spinner = ora(`Running ${name} benchmark`);
+
   suite
     .on("cycle", event => {
       benchmarkResults.push(event);
     })
     .on("complete", () => {
       spinner.stop();
-      showResults(sortDescResults(benchmarkResults));
+      showResults(name, sortDescResults(benchmarkResults));
     })
     .run({ async: true });
 
   spinner.start();
 }
 
-let suite = process.argv[2];
-run(suites[suite]);
+let name = process.argv[2];
+
+if (name) {
+  run(name);
+} else {
+  error('Error: you did not specify a name of suite to run.');
+  info('ie: npm run bench object-append');
+}

--- a/scripts/bench.js
+++ b/scripts/bench.js
@@ -1,0 +1,47 @@
+const ora = require("ora");
+const Table = require("cli-table2");
+
+const suites = {
+  append: require("../benchmarks/append")
+}
+
+const spinner = ora("Running benchmark");
+
+function showResults(benchmarkResults) {
+  let table = new Table({
+    head: ["NAME", "OPS/SEC", "RELATIVE MARGIN OF ERROR", "SAMPLE SIZE"]
+  });
+
+  benchmarkResults.forEach(result => {
+    table.push([
+      result.target.name,
+      result.target.hz.toLocaleString("en-US", { maximumFractionDigits: 0 }),
+      `± ${result.target.stats.rme.toFixed(2)}%`,
+      result.target.stats.sample.length
+    ]);
+  });
+
+  console.log(table.toString()); // eslint-disable-line
+}
+
+function sortDescResults (benchmarkResults) {
+  return benchmarkResults.sort((a, b) => a.target.hz < b.target.hz ? 1 : -1)
+}
+
+function run(suite) {
+  let benchmarkResults = [];
+  suite
+    .on("cycle", event => {
+      benchmarkResults.push(event);
+    })
+    .on("complete", () => {
+      spinner.stop();
+      showResults(sortDescResults(benchmarkResults));
+    })
+    .run({ async: true });
+
+  spinner.start();
+}
+
+let suite = process.argv[2];
+run(suites[suite]);

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,5 +1,5 @@
 const rollup = require("rollup");
-const config = require("./rollup.config");
+const config = require("../rollup.config");
 
 module.exports = function() {
   console.log("\n");


### PR DESCRIPTION
This PR is adding a `bench` script to allow running benchmarks for funcadelic operations. To run a script, you can call `npm run build && npm run bench <suite-name>`. The benchmark suites are in `benchmarks` directory. I added `object-append` suite as an example. 

When you run a benchmark, it'll generate a report like this,

<img width="635" alt="screen shot 2018-04-05 at 8 58 06 am" src="https://user-images.githubusercontent.com/74687/38366994-7fd98d9c-38af-11e8-8f17-fdf8e36bb593.png">

After this is merged, we can create a quest issue to add benchmarks for all operations that we have.