### PR TITLE
Added relative column to bench

### DIFF
--- a/scripts/bench.js
+++ b/scripts/bench.js
@@ -10,13 +10,18 @@ function showResults(name, benchmarkResults) {
   info(`Results for ${name}`);
 
   let table = new Table({
-    head: ["NAME", "OPS/SEC", "RELATIVE MARGIN OF ERROR", "SAMPLE SIZE"]
+    head: ["NAME", "OPS/SEC", "RELATIVE", "RELATIVE MARGIN OF ERROR", "SAMPLE SIZE"]
   });
 
+  let baseline = benchmarkResults[0].target.hz;
+
   benchmarkResults.forEach(result => {
+    let value = result.target.hz;
+    let relative = (baseline / value).toFixed(0);
     table.push([
       result.target.name,
       result.target.hz.toLocaleString("en-US", { maximumFractionDigits: 0 }),
+      baseline === value ? '...' : colors.red(`${relative}x slower`),
       `± ${result.target.stats.rme.toFixed(2)}%`,
       result.target.stats.sample.length
     ]);


### PR DESCRIPTION
This PR adds a column to benchmarks to show how results compare to the top result.

<img width="758" alt="screen shot 2018-04-06 at 8 56 18 am" src="https://user-images.githubusercontent.com/74687/38422375-7f7c0068-3978-11e8-8c38-e53ec05d7ec0.png">
