### PR TITLE
Refactor Object Functor to make it 10x faster

### DIFF
--- a/benchmarks/object-map.js
+++ b/benchmarks/object-map.js
@@ -1,0 +1,62 @@
+const Benchmark = require("benchmark");
+
+const { stable, foldr, append } = require("../dist/funcadelic.cjs");
+const { getPrototypeOf, assign } = Object;
+
+function forMap(fn, object) {
+
+  let descriptors = {};
+  for (let key in object) {
+    descriptors[key] = {
+      enumerable: true,
+      get: stable(() => fn(object[key], key))
+    }
+  }
+
+  return Object.create(getPrototypeOf(object), descriptors);
+}
+
+function foldrAppendMap(fn, object) {
+  let properties = foldr(function(properties, entry) {
+    return append(properties, {
+      [entry.key]: {
+        enumerable: true,
+        get: stable(() => fn(entry.value, entry.key))
+      }
+    });
+  }, {}, object);
+  let prototype = getPrototypeOf(object);
+  return Object.create(prototype, properties);
+}
+
+function foldrAssignMap(fn, object) {
+  let properties = foldr(function(properties, entry) {
+    return assign({}, properties, {
+      [entry.key]: {
+        enumerable: true,
+        get: stable(() => fn(entry.value, entry.key))
+      }
+    });
+  }, {}, object);
+  let prototype = getPrototypeOf(object);
+  return Object.create(prototype, properties);
+}
+
+let data = { a: 'a', b: 'b', c: 'c', d: 'd', e: 'e', f: 'f', g: 'g', h: 'h', k: 'k' };
+
+module.exports = new Benchmark.Suite()
+  .add("map with foldr and append", () => {
+    for (let i = 0; i < 1000; i++) {
+      foldrAppendMap(v => v, data);
+    }
+  })
+  .add("map with foldr and assign", () => {
+    for (let i = 0; i < 1000; i++) {
+      foldrAssignMap(v => v, data);
+    }
+  })
+  .add("map with for", () => {
+    for (let i = 0; i < 1000; i++) {
+      forMap(v => v, data);
+    }
+  });

--- a/benchmarks/object-map.js
+++ b/benchmarks/object-map.js
@@ -15,8 +15,8 @@ function forMap(fn, object) {
   return Object.create(getPrototypeOf(object), descriptors);
 }
 
-function foldrMutateMap(fn, object) {
-  
+function keysReduceMutateMap(fn, object) {
+
   let descriptors = keys(object).reduce((acc, key) => {
     acc[key] = {
       enumerable: true,
@@ -57,9 +57,9 @@ function foldrAssignMap(fn, object) {
 let data = { a: 'a', b: 'b', c: 'c', d: 'd', e: 'e', f: 'f', g: 'g', h: 'h', k: 'k' };
 
 module.exports = new Benchmark.Suite()
-  .add("map with foldr and mutate", () => {
+  .add("map with Object.keys(object).reduce and mutate descriptors", () => {
     for (let i = 0; i < 1000; i++) {
-      foldrMutateMap(v => v, data);
+      keysReduceMutateMap(v => v, data);
     }
   })
   .add("map with foldr and append", () => {

--- a/src/functor/object.js
+++ b/src/functor/object.js
@@ -6,12 +6,13 @@ const { getPrototypeOf, keys } = Object;
 Functor.instance(Object, {
   map(fn, object) {
 
-    let descriptors = keys(object).reduce((acc, key) => {
-      acc[key] = {
+    let descriptors = keys(object).reduce((descriptors, key) => {
+      descriptors[key] = {
+        configurable: true,
         enumerable: true,
         get: stable(() => fn(object[key], key))
       }
-      return acc;
+      return descriptors;
     }, {});
 
     return Object.create(getPrototypeOf(object), descriptors);

--- a/src/functor/object.js
+++ b/src/functor/object.js
@@ -1,21 +1,19 @@
 import { Functor } from '../functor';
-import { append } from '../semigroup';
-import { foldr } from '../foldable';
 import stable from '../stable';
 
 const { getPrototypeOf } = Object;
 
 Functor.instance(Object, {
   map(fn, object) {
-    let properties = foldr(function(properties, entry) {
-      return append(properties, {
-        [entry.key]: {
-          enumerable: true,
-          get: stable(() => fn(entry.value, entry.key))
-        }
-      });
-    }, {}, object);
-    let prototype = getPrototypeOf(object);
-    return Object.create(prototype, properties);
+    
+    let descriptors = {};
+    for (let key in object) {
+      descriptors[key] = {
+        enumerable: true,
+        get: stable(() => fn(object[key], key))
+      }
+    }
+  
+    return Object.create(getPrototypeOf(object), descriptors);
   }
 });

--- a/src/functor/object.js
+++ b/src/functor/object.js
@@ -1,19 +1,19 @@
 import { Functor } from '../functor';
 import stable from '../stable';
 
-const { getPrototypeOf } = Object;
+const { getPrototypeOf, keys } = Object;
 
 Functor.instance(Object, {
   map(fn, object) {
-    
-    let descriptors = {};
-    for (let key in object) {
-      descriptors[key] = {
+
+    let descriptors = keys(object).reduce((acc, key) => {
+      acc[key] = {
         enumerable: true,
         get: stable(() => fn(object[key], key))
       }
-    }
-  
+      return acc;
+    }, {});
+
     return Object.create(getPrototypeOf(object), descriptors);
   }
 });


### PR DESCRIPTION
append is a relatively expensive operation. I added benchmarks to show how it compares relative to using other options. 

<img width="1280" alt="screen shot 2018-04-30 at 12 22 31 am" src="https://user-images.githubusercontent.com/74687/39415052-a1dad8e0-4c0c-11e8-819d-9f5b22c93b72.png">

map with append is 10x slower than using `Object.keys(object).reduce` & mutating descriptor `{}`. This PR changes object map implementation to use the faster method and benchmark file.

