### PR TITLE
Use `extend-shallow` instead of `Object.assign` for React Native

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dist"
   ],
   "dependencies": {
+    "extend-shallow": "^3.0.2",
     "lodash.curry": "4.1.1",
     "object.getownpropertydescriptors": "2.0.3"
   },

--- a/src/semigroup/object.js
+++ b/src/semigroup/object.js
@@ -2,8 +2,9 @@ import { Semigroup } from '../semigroup';
 import { foldl } from '../foldable';
 import propertiesOf from 'object.getownpropertydescriptors';
 import stable from '../stable';
+import assign from 'extend-shallow';
 
-const { assign, getPrototypeOf, getOwnPropertySymbols, keys } = Object;
+const { getPrototypeOf, getOwnPropertySymbols, keys } = Object;
 
 Semigroup.instance(Object, {
   append(o1, o2) {


### PR DESCRIPTION
## What is this? 

When debugging microstates in React Native we discovered that
`Object.assign` does not copy over Symbols since React Native is
using their own version of `Object.assign`:
https://github.com/facebook/react-native/blob/master/Libraries/polyfills/Object.es6.js#L12

`extend-shallow` is a popular alternative that supports assigning
Symbols and works in React Native.