### PR TITLE
Using local assign in Object Semigroup

### DIFF
--- a/benchmarks/object-append.js
+++ b/benchmarks/object-append.js
@@ -2,6 +2,22 @@ const Benchmark = require("benchmark");
 
 const { append } = require("../dist/funcadelic.cjs");
 
+function likeAssign(target) {
+  let totalArgs = arguments.length,
+      source, i, totalKeys, keys, key, j;
+
+  for (i = 1; i < totalArgs; i++) {
+    source = arguments[i];
+    keys = Object.keys(source).concat(Object.getOwnPropertySymbols(source));
+    totalKeys = keys.length;
+    for (j = 0; j < totalKeys; j++) {
+      key = keys[j];
+      target[key] = source[key];
+    }
+  }
+  return target;
+}
+
 module.exports = new Benchmark.Suite()
   .add("append", () => {
     class Person {}
@@ -9,7 +25,13 @@ module.exports = new Benchmark.Suite()
       append(new Person(), { firstName: 'Foo', lastName: 'Bar' });
     }
   })
-  .add("assign", () => {
+  .add("likeAssign", () => {
+    class Person {}
+    for (let i = 0; i < 1000; i++) {
+      likeAssign(new Person(), { firstName: 'Foo', lastName: 'Bar' });
+    }
+  })
+  .add("Object.assign", () => {
     class Person {}
     for (let i = 0; i < 1000; i++) {
       Object.assign(new Person(), { firstName: 'Foo', lastName: 'Bar' });

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "dist"
   ],
   "dependencies": {
-    "extend-shallow": "^3.0.2",
     "lodash.curry": "4.1.1",
     "object.getownpropertydescriptors": "2.0.3"
   },

--- a/src/semigroup/object.js
+++ b/src/semigroup/object.js
@@ -20,19 +20,20 @@ Semigroup.instance(Object, {
  * We need this to prevent append from breaking in React Native 
  * @see https://github.com/facebook/react-native/blob/master/Libraries/polyfills/Object.es6.js#L12
  */
-function assign(target) {
-  let totalArgs = arguments.length,
-      source, i, totalKeys, keys, key, j;
+function assign(target, a, b) {
 
-  for (i = 1; i < totalArgs; i++) {
-    source = arguments[i];
-    keys = Object.keys(source).concat(Object.getOwnPropertySymbols(source));
-    totalKeys = keys.length;
-    for (j = 0; j < totalKeys; j++) {
-      key = keys[j];
+  function copy(source) {    
+    let keys = Object.keys(source).concat(Object.getOwnPropertySymbols(source));
+    let totalKeys = keys.length;
+    for (let j = 0; j < totalKeys; j++) {
+      let key = keys[j];
       target[key] = source[key];
     }
   }
+  
+  copy(a);
+  copy(b);
+
   return target;
 }
 

--- a/src/semigroup/object.js
+++ b/src/semigroup/object.js
@@ -16,6 +16,9 @@ Semigroup.instance(Object, {
  * Analogue of Object.assign(). Copies properties from one or more source objects to
  * a target object. Existing keys on the target object will be overwritten. 
  * Modified to support copying Symbols.
+ * 
+ * We need this to prevent append from breaking in React Native 
+ * @see https://github.com/facebook/react-native/blob/master/Libraries/polyfills/Object.es6.js#L12
  */
 function assign(target) {
   let totalArgs = arguments.length,

--- a/src/semigroup/object.js
+++ b/src/semigroup/object.js
@@ -2,9 +2,8 @@ import { Semigroup } from '../semigroup';
 import { foldl } from '../foldable';
 import propertiesOf from 'object.getownpropertydescriptors';
 import stable from '../stable';
-import assign from 'extend-shallow';
 
-const { getPrototypeOf, getOwnPropertySymbols, keys } = Object;
+const { getPrototypeOf } = Object;
 
 Semigroup.instance(Object, {
   append(o1, o2) {
@@ -12,6 +11,27 @@ Semigroup.instance(Object, {
     return Object.create(getPrototypeOf(o1), stableize(properties));
   }
 });
+
+/**
+ * Analogue of Object.assign(). Copies properties from one or more source objects to
+ * a target object. Existing keys on the target object will be overwritten. 
+ * Modified to support copying Symbols.
+ */
+function assign(target) {
+  let totalArgs = arguments.length,
+      source, i, totalKeys, keys, key, j;
+
+  for (i = 1; i < totalArgs; i++) {
+    source = arguments[i];
+    keys = Object.keys(source).concat(Object.getOwnPropertySymbols(source));
+    totalKeys = keys.length;
+    for (j = 0; j < totalKeys; j++) {
+      key = keys[j];
+      target[key] = source[key];
+    }
+  }
+  return target;
+}
 
 /**
  * Make all of the computed values in this set of property descriptors
@@ -26,18 +46,15 @@ function stableize(properties) {
   return foldl((descriptors, key) => {
     let descriptor = properties[key];
     if (!descriptor.get) {
-      return assign({}, descriptors, {
-        [key]: descriptor
-      });
+      descriptors[key] = descriptor;
     } else {
-      let cached = stable(instance => descriptor.get.call(instance));
-      return assign({}, descriptors, {
-        [key]: assign({}, descriptor, {
-          get() {
-            return cached(this);
-          }
-        })
-      });
+      let getter = descriptor.get;
+      let cached = stable(instance => getter.call(instance));
+      descriptor.get = function() {
+        return cached(this);
+      };
+      descriptors[key] = descriptor;
     }
-  }, {}, keys(properties).concat(getOwnPropertySymbols(properties)));
+    return descriptors;
+  }, {}, Object.keys(properties).concat(Object.getOwnPropertySymbols(properties)));
 }

--- a/tests/funcadelic.test.js
+++ b/tests/funcadelic.test.js
@@ -37,6 +37,13 @@ describe('Semigroup', function() {
   it('appends objects', function() {
     expect(append({one: 1, two: 2}, {two: 'two', three: 3})).toEqual({one: 1, two: 'two', three: 3});
   });
+  it('copies symbols', () => {
+    let a1 = Symbol();
+    let a2 = Symbol();
+    let result = append({ [a1]: true }, { [a2]: 42 });
+    expect(result[a1]).toBe(true);
+    expect(result[a2]).toBe(42);
+  });
   it('appends arrays', function() {
     expect(append([1,2,3], [4,4,4])).toEqual([1,2,3,4,4,4]);
   });


### PR DESCRIPTION
It turns out that `extend-shallow` does not work as expected because it actually defaults to `Object.assign` when available. We need to always use our own implementation of `Object.assign` inside of Object Semigroup to prevent React Native from overwriting our assign with theirs. 

The implementation that I added is just a little slower than `Object.assign`. 
<img width="743" alt="screen shot 2018-05-15 at 1 27 15 pm" src="https://user-images.githubusercontent.com/74687/40073036-b4908b2c-5843-11e8-9bee-605bdf1f06bf.png">

I can get it to be little faster than `Object.assign`, but I need to replace `Object.keys(source).concat(Object.getOwnPropertySymbols(source))` with the following,

```js
function allKeys(o) {
  let keys = Object.keys(o), 
      keysLength = keys.length,
      symbols = Object.getOwnPropertySymbols(o),
      symbolsLength = symbols.length,
      arr = Array(keysLength + symbolsLength),
      totalLength = keysLength + symbolsLength;

  for (let j = 0; j < keysLength; j++) {
    arr[j] = keys[j];
  }
  for (let j = keysLength; j < totalLength; j++) {
    arr[j] = symbols[totalLength - j - 1];
  }
  return arr;
}
```

I decided to not use it because it's pretty ugly, but we can always add it back.