### PR TITLE
Replace lodash.curry with something smaller

### DIFF
--- a/benchmarks/curry.js
+++ b/benchmarks/curry.js
@@ -1,0 +1,41 @@
+const Benchmark = require("benchmark");
+const compose = require('lodash.flow');
+
+const lodashCurry = require('lodash.curry');
+
+function curry(f) {
+  return function curried(...t) {
+      if (t.length === 0) return curried;
+      if (t.length === f.length) return f(...t);
+      return curried.bind(this, ...t);
+  };
+}
+
+const fixedArityFns = [
+  (a, b) => a + b,
+  (a, b, c) => a + b + c,
+  (a, b, c, d) => a + b + c + d,
+  (a, b, c, d, e) => a + b + c + d + e,
+  (a, b, c, d, e, f) => a + b + c + d + e + f,
+  (a, b, c, d, e, f, g) => a + b + c + d + e + f + g,
+  (a, b, c, d, e, f, g, h) => a + b + c + d + e + f + g + h,
+  (a, b, c, d, e, f, g, h, i) => a + b + c + d + e + f + g + h + i,
+  (a, b, c, d, e, f, g, h, i, j) => a + b + c + d + e + f + g + h + i + j
+];
+
+const values = [1, 23, 42, 67, 99, 112, 250, 667, 888, 1001];
+
+function bench(name, curryFn) {
+  return function(suite) {
+    return fixedArityFns.reduce((memo, fn, length) => {
+      let arity = length + 2;
+      let args = values.slice(0, arity);
+      let sum = curryFn(fn);
+      return memo.add(`${name} function with ${arity} arity`, () => {
+        args.reduce((acc, j) => acc(j), sum);
+      });
+    }, suite);
+  }
+}
+
+module.exports = compose([bench('_.curry', lodashCurry), bench('curry', curry)])(new Benchmark.Suite());

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "dist"
   ],
   "dependencies": {
-    "invariant": "2.2.4",
-    "lodash.curry": "4.1.1"
+    "fk": "1.0.0",
+    "invariant": "2.2.4"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-beta.44",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "dist"
   ],
   "dependencies": {
-    "fk": "1.0.0",
     "invariant": "2.2.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "eslint": "4.19.1",
     "eslint-plugin-prefer-let": "1.0.1",
     "jest": "22.4.3",
+    "lodash.curry": "4.1.1",
+    "lodash.flow": "3.5.0",
     "object.getownpropertydescriptors": "2.0.3",
     "ora": "2.0.0",
     "regenerator-runtime": "0.11.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,8 +3,8 @@ const filesize = require("rollup-plugin-filesize");
 const pkg = require("./package.json");
 
 const globals = {
-  "lodash.curry": "_.curry",
-  "invariant": "invariant"
+  "invariant": "invariant",
+  "fk": "fk"
 };
 
 let external = Object.keys(globals);

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,8 +3,7 @@ const filesize = require("rollup-plugin-filesize");
 const pkg = require("./package.json");
 
 const globals = {
-  "invariant": "invariant",
-  "fk": "fk"
+  "invariant": "invariant"
 };
 
 let external = Object.keys(globals);

--- a/src/applicative.js
+++ b/src/applicative.js
@@ -1,7 +1,7 @@
 import { Functor } from './functor';
 import { foldl } from './foldable';
 import { type } from './typeclasses';
-import curry from 'lodash.curry';
+import curry from 'fk';
 
 export const Applicative = type(class Applicative extends Functor {
   pure(Type, value) {

--- a/src/applicative.js
+++ b/src/applicative.js
@@ -1,7 +1,14 @@
 import { Functor } from './functor';
 import { foldl } from './foldable';
 import { type } from './typeclasses';
-import curry from 'fk';
+
+function curry(f) {
+  return function curried(...t) {
+      if (t.length === 0) return curried;
+      if (t.length === f.length) return f(...t);
+      return curried.bind(this, ...t);
+  };
+}
 
 export const Applicative = type(class Applicative extends Functor {
   pure(Type, value) {

--- a/src/applicative.js
+++ b/src/applicative.js
@@ -2,10 +2,10 @@ import { Functor } from './functor';
 import { foldl } from './foldable';
 import { type } from './typeclasses';
 
-function curry(f) {
+export function curry(f) {
   return function curried(...t) {
       if (t.length === 0) return curried;
-      if (t.length === f.length) return f(...t);
+      if (t.length >= f.length) return f(...t);
       return curried.bind(this, ...t);
   };
 }

--- a/tests/funcadelic.test.js
+++ b/tests/funcadelic.test.js
@@ -1,6 +1,7 @@
 import 'jest';
 
 import { apply, map, append, foldr, foldl, filter, pure, reduce, flatMap, Monoid, Functor, type, stable } from 'funcadelic';
+import {curry} from '../src/applicative';
 
 function promise(result) {
   return Promise.resolve(result);
@@ -204,5 +205,26 @@ describe('stable function', () => {
       let stabilized = stable(arg => arg);
       expect(stable(stabilized)).toBe(stabilized);
     });
+  });
+});
+
+describe('curry', () => {
+  let curried = curry(function (x, y) { return [].slice.call(arguments)});
+  let partial = curried(1);
+  
+  it('returns curried function when passing one argument', () => {
+    expect(partial).toBeInstanceOf(Function);
+  });
+  it('receives all arguments when partial function receives all expected arguments', () => {
+    expect(partial(2)).toEqual([1, 2]);
+  });
+  it('receives all arguments when partial function receives more than expected arguments', () => {
+    expect(partial(2, 3)).toEqual([1, 2, 3]);
+  });
+  it('returns value when all arguments passed', () => {
+    expect(curried(1, 2)).toEqual([1, 2]);
+  });
+  it('supports extra arguments', () => {
+    expect(curried(1, 2, 3)).toEqual([1, 2, 3]);
   });
 });


### PR DESCRIPTION
lodash.curry is 2.5KB gzipped. According to my benchmarks, this function is faster than `lodash.curry` too but it doesn't support placeholders which we are not using.

```js
function curry(f) {
  return function curried(...t) {
      if (t.length === 0) return curried;
      if (t.length === f.length) return f(...t);
      return curried.bind(this, ...t);
  };
}
``` 

<img width="804" alt="screen shot 2018-05-22 at 8 20 50 am" src="https://user-images.githubusercontent.com/74687/40362015-42644d94-5d99-11e8-9a86-da52a90a7b43.png">
