### PR TITLE
Using @@Funcadelic/${Typeclass} instead of symbols

### DIFF
--- a/src/typeclasses.js
+++ b/src/typeclasses.js
@@ -1,11 +1,11 @@
 import invariant from 'invariant';
 
-const { keys, getOwnPropertyDescriptors } = Object;
-
-invariant(getOwnPropertyDescriptors, `funcadelic.js requires Object.getOwnPropertyDescriptors. See https://github.com/cowboyd/funcadelic.js#compatibility`)
-invariant("name" in Function.prototype && "name" in (function x() {}), `funcadelic.js requires Function.name. See https://github.com/cowboyd/funcadelic.js#compatibility`);
+const { keys, getOwnPropertyDescriptors, defineProperty } = Object;
 
 export function type(Class) {
+
+  invariant(Object.getOwnPropertyDescriptors, `funcadelic.js requires Object.getOwnPropertyDescriptors. See https://github.com/cowboyd/funcadelic.js#compatibility`)
+  invariant("name" in Function.prototype && "name" in (function x() {}), `funcadelic.js requires Function.name. See https://github.com/cowboyd/funcadelic.js#compatibility`);
 
   let name = Class.name;
 
@@ -13,7 +13,7 @@ export function type(Class) {
     throw new Error('invalid typeclass name: ' + name);
   }
 
-  let symbol = Symbol(name);
+  let symbol = `@@Funcadelic/${name}`;
 
   Class.for = function _for(value) {
     let i = value[symbol];
@@ -24,7 +24,11 @@ export function type(Class) {
   };
 
   Class.instance = function(constructor, methods) {
-    constructor.prototype[symbol] = methods;
+    defineProperty(constructor.prototype, symbol, {
+      value: methods,
+      enumerable: false,
+      configurable: true
+    });
   };
 
   Class.symbol = symbol;

--- a/tests/funcadelic.test.js
+++ b/tests/funcadelic.test.js
@@ -180,7 +180,7 @@ describe('Monad', function() {
 describe('A Typeclass', function () {
   it('has an associated symbol', function() {
     expect(Functor.symbol).toBeDefined();
-    expect(Object.getOwnPropertySymbols(Object.prototype)).toContain(Functor.symbol);
+    expect(Object.getOwnPropertyNames(Object.prototype)).toContain(Functor.symbol);
   });
 });
 


### PR DESCRIPTION
Currently, we're using Symbols to store Typeclass methods on the prototype. This is problematic because when a module is imported by other modules, it sometimes creates different symbols. This causes weird and hard to track down issues. Usually, this results in an incorrect method being to operate on some data.

This PR replaces symbols with a string identifier based using pattern `@@Funcadelic/${Typeclass}`. 

Changes
- Removed symbol
- Make sure that property is not enumerable
- Moved invariant validation into `type` function

Related #45 