### PR TITLE
Attach symbols to global

### DIFF
--- a/src/typeclasses.js
+++ b/src/typeclasses.js
@@ -5,6 +5,8 @@ const { keys, getOwnPropertyDescriptors } = Object;
 invariant(getOwnPropertyDescriptors, `funcadelic.js requires Object.getOwnPropertyDescriptors. See https://github.com/cowboyd/funcadelic.js#compatibility`)
 invariant("name" in Function.prototype && "name" in (function x() {}), `funcadelic.js requires Function.name. See https://github.com/cowboyd/funcadelic.js#compatibility`);
 
+const VERSION = 0;
+
 export function type(Class) {
 
   let name = Class.name;
@@ -13,7 +15,8 @@ export function type(Class) {
     throw new Error('invalid typeclass name: ' + name);
   }
 
-  let symbol = Symbol(name);
+  let symbolName = `@@funcadelic-${VERSION}/${name}`;
+  let symbol = Symbol[symbolName] ? Symbol[symbolName] : Symbol[symbolName] = Symbol(symbolName);
 
   Class.for = function _for(value) {
     let i = value[symbol];

--- a/tests/funcadelic.test.js
+++ b/tests/funcadelic.test.js
@@ -11,9 +11,22 @@ describe('typeclasses', function() {
   it('exports type function', function() {
     expect(type).toBeInstanceOf(Function);
   });
+  describe('global registration', () => {
+    class MyClass {}
+    let Typeclass;
+    beforeEach(() => {
+      Typeclass = type(MyClass);
+    });
+    it('attached typeclass to Symbol', () => {
+      expect(Symbol['@@funcadelic-0/MyClass']).toBe(Typeclass.symbol);
+    });
+  });
 });
 
 describe('Functor', function() {
+  it('attached typeclass to global Symbol', () => {
+    expect(typeof Symbol['@@funcadelic-0/Functor']).toBe('symbol');
+  });
   it('maps objects', function() {
     expect(map((i) => i * 2, {one: 1, two: 2})).toEqual({one: 2, two: 4});
   });


### PR DESCRIPTION
To address problem described in #46 and #45 this PR will store typeclass symbols on global `Symbol` object. The typeclass will attempt to retrieve the symbol from the global object before creating a new Symbol. This will ensure that all modules will always use one identity for each typeclass.