### PR TITLE
Add Jest eslint plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "rollup --config",
     "bench": "node ./scripts/bench",
-    "lint": "eslint src",
+    "lint": "eslint src tests",
     "pretest": "npm run build && npm run lint",
     "test": "jest",
     "prepare": "npm test",
@@ -33,7 +33,8 @@
     "benchmark": "2.1.4",
     "cli-table2": "0.2.0",
     "colors": "1.2.1",
-    "eslint": "4.19.1",
+    "eslint": "^5.0.1",
+    "eslint-plugin-jest": "^21.17.0",
     "eslint-plugin-prefer-let": "1.0.1",
     "jest": "22.4.3",
     "lodash.curry": "4.1.1",

--- a/tests/.eslintrc.json
+++ b/tests/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "plugins": ["jest"],
+  "extends": ["plugin:jest/recommended"],
+  "env": {
+    "jest/globals": true
+  }
+}

--- a/tests/funcadelic.test.js
+++ b/tests/funcadelic.test.js
@@ -1,5 +1,3 @@
-import 'jest';
-
 import { apply, map, append, foldr, foldl, filter, pure, reduce, flatMap, Monoid, Functor, type, stable } from 'funcadelic';
 import {curry} from '../src/applicative';
 
@@ -31,7 +29,7 @@ describe('Functor', function() {
     expect(map((i) => i * 2, {one: 1, two: 2})).toEqual({one: 2, two: 4});
   });
   it('maps objects, and maintains stability over its values.', function() {
-    let objects =  map(i => ({}), {one: 1, two: 2});
+    let objects =  map(() => ({}), {one: 1, two: 2});
     expect(objects.one).toBe(objects.one);
   });
   it('maps arrays', function() {
@@ -208,9 +206,10 @@ describe('stable function', () => {
     it('caches result when passed an object', () => {
       let one = {};
       let two = {};
-      let dateMaker = instance => new Date();
+
+      let dateMaker = instance => new Date(); //eslint-disable-line no-unused-vars
       let stableDateMaker = stable(dateMaker);
-      expect(stableDateMaker(one)).toBe(stableDateMaker(one)); 
+      expect(stableDateMaker(one)).toBe(stableDateMaker(one));
       expect(stableDateMaker(two)).toBe(stableDateMaker(two));
       expect(stableDateMaker(one)).not.toBe(stableDateMaker(two));
     });
@@ -222,9 +221,10 @@ describe('stable function', () => {
 });
 
 describe('curry', () => {
+  //eslint-disable-next-line no-unused-vars
   let curried = curry(function (x, y) { return [].slice.call(arguments)});
   let partial = curried(1);
-  
+
   it('returns curried function when passing one argument', () => {
     expect(partial).toBeInstanceOf(Function);
   });


### PR DESCRIPTION
Because of the Jest global environment, it really throws off the default eslint style rules, and spews a lot of unnecessary warnings about global variables.

Before:

![image](https://user-images.githubusercontent.com/4205/42117050-cc11cde6-7bb7-11e8-97c1-9d20bfea91d8.png)

After:

![image](https://user-images.githubusercontent.com/4205/42117113-1193bc76-7bb8-11e8-84da-a5739f405977.png)


This adds the jest plugin to whitelist Jest globals as well as the recommended ruleset. It also style checks the tests.