### PR TITLE
Add support for the chaining API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ append({name: 'Charles'}, {occupation: 'Developer'}) //=> {name: 'Charles', occu
 When you smush two members of a semigroup together, you always get the
 same type back. In that example above: `Object + Object => Object`
 
-And when you smush multiple members of a semigroup together, it doesn't 
+And when you smush multiple members of a semigroup together, it doesn't
 matter which ones you smush together first, you get the same answer either way:
 
 ```javascript
@@ -497,14 +497,55 @@ you find yourself coming up against problems and wondering which to
 use and this documentation doesn't help. Shoot me a line and we can
 talk it over about how to improve it. When in doubt, `foldl`.
 
+## Chaining API
+
+Funcadelic is great for composition, but because of JavaScripts syntax
+composing a sequence of operations can be awkward. For example,
+suppose you have some variable `start` that you want to map over,
+then filter, then append to, and then map again. You'd have to write
+something like:
+
+```js
+let result = map(f2, append(filter(predicate, map(f1, start))))
+```
+
+Picking apart those expressions and divining the intent is a difficult
+task even for the most experienced set of eyes.
+
+With the chain api, you can rewrite the above as:
+
+```js
+import { chain as $ } from 'funcadelic';
+
+$(start)
+  .map(f1)
+  .filter(predicate)
+  .append(something)
+  .map(f2)
+  .valueOf();
+```
+
+Which very clearly describes the sequence of operations.
+
+Each method invocation takes the current value of the chain, applies
+the transformation using the current value as the last argument, and
+then returns a new chain contain the result of that operation.
+
+Notice how we had to call `valueOf()` as the very last step in our
+chain? This takes the current value of the chain and returns it.
+
+> Pro tip: Chaining is lazy, so not only do we need to call
+> `valueOf()` to get the final result from the chain, but also nothing
+> actually happens at all until we do!
+
 ## Compatibility
 
-Funcadelic uses `Object.getOwnPropertyDescriptors` which is not supported by all environments, namely <IE11 and <Node 6. 
-You may consider using a [polyfill](https://www.npmjs.com/package/object.getownpropertydescriptors) if you require support 
-for these environments. 
+Funcadelic uses `Object.getOwnPropertyDescriptors` which is not supported by all environments, namely <IE11 and <Node 6.
+You may consider using a [polyfill](https://www.npmjs.com/package/object.getownpropertydescriptors) if you require support
+for these environments.
 
-Funcadelic uses `Function.name` to determine the name of the constructor when creating typeclasses. 
-Unfortunately, IE11 does not support retrieving the name of a function. You may use [Function.name polyfill](https://github.com/JamesMGreene/Function.name) to make this feature available in IE11. 
+Funcadelic uses `Function.name` to determine the name of the constructor when creating typeclasses.
+Unfortunately, IE11 does not support retrieving the name of a function. You may use [Function.name polyfill](https://github.com/JamesMGreene/Function.name) to make this feature available in IE11.
 
 ## Development
 

--- a/src/chain.js
+++ b/src/chain.js
@@ -1,0 +1,53 @@
+import { append } from './semigroup';
+import { map } from './functor';
+import { flatMap } from './monad';
+import { filter } from './filterable';
+import stable  from './stable';
+
+class Chain {
+  map(fn) {
+    return new Thunk(() => map(fn, this.valueOf()));
+  }
+
+  flatMap(fn) {
+    return new Thunk(() => flatMap(fn, this.valueOf()));
+  }
+
+  filter(fn) {
+    return new Thunk(() => filter(fn, this.valueOf()));
+  }
+
+  append(thing) {
+    return new Thunk(() => append(this.valueOf(), thing));
+  }
+
+  tap(fn) {
+    fn(this.valueOf());
+    return this;
+  }
+}
+
+class Value extends Chain {
+  constructor(value) {
+    super();
+    this.value = value;
+  }
+
+  valueOf() {
+    return this.value;
+  }
+}
+
+class Thunk extends Chain {
+  constructor(fn) {
+    super();
+    this.fn = stable(fn);
+  }
+  valueOf() {
+    return this.fn();
+  }
+}
+
+export default function chain(value) {
+  return new Value(value);
+}

--- a/src/funcadelic.js
+++ b/src/funcadelic.js
@@ -29,3 +29,5 @@ import './filterable/object';
 import './filterable/array';
 
 export { default as stable } from './stable';
+
+export { default as chain } from './chain';

--- a/tests/chain.test.js
+++ b/tests/chain.test.js
@@ -1,0 +1,37 @@
+import { chain as $ } from 'funcadelic';
+
+describe('Chain', function() {
+  it('can map', function() {
+    expect($([1,2,4])
+           .map(x => x * 2)
+           .map(x => x * 2)
+           .valueOf()).toEqual([4, 8, 16])
+  });
+  it('can flatMap', function() {
+    expect($([1,2,3])
+           .flatMap(x => [x * x, x * x])
+           .flatMap(x => [x * 2])
+           .valueOf()).toEqual([2,2, 8, 8, 18, 18])
+  });
+  it('can append', function() {
+    expect($(['hello'])
+           .append('world')
+           .append('!')
+           .valueOf()).toEqual(['hello', 'world', '!'])
+  });
+  it('can filter', function() {
+    expect($(['spray', 'limit', 'elite', 'exuberant', 'destruction', 'present'])
+           .filter(word => word.length > 6)
+           .valueOf()).toEqual(["exuberant", "destruction", "present"])
+  });
+  it('can tap', function() {
+    let tapped;
+    expect($('Tha Thing')
+           .tap(subject => {
+             tapped = subject;
+             return 'OTHER THING';
+           })
+           .valueOf()).toEqual('Tha Thing');
+    expect(tapped).toEqual('Tha Thing');
+  });
+});


### PR DESCRIPTION
Funcadelic is great for composition, but because of JavaScripts syntax and rightwards associativity, composing a sequence of operations can be awkward. For example, suppose I want to map something, then filter it, then append to it, and then map it again. I'd have to write something like:

```js
let result = map(f2, append(filter(predicate, map(f1, start))))
```

Picking apart the expressions and divining the intent is a difficult task even for the most experienced set of eyes.

With the chain api, you can rewrite the above as:

```js
import { chain as $ } from 'funcadelic';

$(start)
  .map(f1)
  .filter(predicate)
  .append(something)
  .map(f2)
  .valueOf();
```

Which very clearly describes the sequence of operations.

Each method invocation takes the current value of the chain, applies the transformation using the current value as the last argument, and then returns a new chain contain the result of that operation.