### PR TITLE
Release notes for 0.5.2 which includes chaining api.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2018-07-02 - [v0.5.0...v0.5.1](https://github.com/cowboyd/funcadelic.js/compare/v0.5.1...v0.5.2)
+
+### Added
+
+- chaining operator for composing sequences of maps, flatMaps,
+  appends, filters, and folds. https://github.com/cowboyd/funcadelic.js/pull/53
+
 ## [0.5.1] - 2018-06-29 - [v0.5.0...v0.5.1](https://github.com/cowboyd/funcadelic.js/compare/v0.5.0...v0.5.1)
+
+### Changed
 
 - Use native classes in Node.js https://github.com/cowboyd/funcadelic.js/pull/49
 
 ## [0.5.0] - 2018-05-30
 
+### Changed
+
 - Attach symbols to global Symbol object https://github.com/cowboyd/funcadelic.js/pull/48
 
 ## [0.4.3] - 2018-05-22
 
+### Changed
+
 - Replace lodash.curry with something smaller https://github.com/cowboyd/funcadelic.js/pull/44
 
 ## [0.4.2] - 2018-05-17
+
+### Changed
 
 - Remove dependency on object.getownpropertydescriptors https://github.com/cowboyd/funcadelic.js/pull/43
 - Using local assign in Object Semigroup https://github.com/cowboyd/funcadelic.js/pull/42

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "funcadelic",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Functional Fundamentals are Fun!",
   "main": "dist/funcadelic.cjs.js",
   "module": "dist/funcadelic.es.js",


### PR DESCRIPTION
Also at the same time fixed up older changelog entries to conform to
the spec.