### PR TITLE
Add unique identifier to typeclass symbol names

### DIFF
--- a/src/typeclasses.js
+++ b/src/typeclasses.js
@@ -6,6 +6,7 @@ invariant(getOwnPropertyDescriptors, `funcadelic.js requires Object.getOwnProper
 invariant("name" in Function.prototype && "name" in (function x() {}), `funcadelic.js requires Function.name. See https://github.com/cowboyd/funcadelic.js#compatibility`);
 
 const VERSION = 0;
+let uniqueTag = 0;
 
 export function type(Class) {
 
@@ -15,7 +16,7 @@ export function type(Class) {
     throw new Error('invalid typeclass name: ' + name);
   }
 
-  let symbolName = `@@funcadelic-${VERSION}/${name}`;
+  let symbolName = `@@funcadelic-${VERSION}/${name}/${uniqueTag++}`;
   let symbol = Symbol[symbolName] ? Symbol[symbolName] : Symbol[symbolName] = Symbol(symbolName);
 
   Class.for = function _for(value) {


### PR DESCRIPTION
## What is this?
This adds a unique tag to the typeclass symbol names because sometimes
build systems will mangle the class names.

What was happening was that `Functor` and `Filterable` were unique
within their own scopse, so the class name became “e”. That caused
funcadelic to look up the instance for `Functor` and getting
`Filterable` because they both had `"@@funcadelic-0/e"` as their
symbol name