### PR TITLE
Add uniqueTag to class name rather than checking for mangling

### DIFF
--- a/src/typeclasses.js
+++ b/src/typeclasses.js
@@ -16,7 +16,7 @@ let uniqueTag = 0;
 
 export function type(Class) {
 
-  let name = hasBeenMangled ? uniqueTag++ : Class.name;
+  let name = hasBeenMangled ? `${Class.name}/${uniqueTag++}` : Class.name;
 
   if (!name) {
     throw new Error('invalid typeclass name: ' + name);

--- a/src/typeclasses.js
+++ b/src/typeclasses.js
@@ -6,23 +6,17 @@ invariant(getOwnPropertyDescriptors, `funcadelic.js requires Object.getOwnProper
 invariant("name" in Function.prototype && "name" in (function x() {}), `funcadelic.js requires Function.name. See https://github.com/cowboyd/funcadelic.js#compatibility`);
 
 const VERSION = 0;
-
-// A function that exists to check if the compiler is crushing
-// function names. If it is we need to use `uniqueTag` to make sure
-// there's no collisions when looking up `symbolNames`
-function isCrushed() {}
-let hasBeenMangled = typeof isCrushed.name === 'string' && isCrushed.name !== 'isCrushed';
 let uniqueTag = 0;
 
 export function type(Class) {
 
-  let name = hasBeenMangled ? `${Class.name}/${uniqueTag++}` : Class.name;
+  let name =  Class.name;
 
   if (!name) {
     throw new Error('invalid typeclass name: ' + name);
   }
 
-  let symbolName = `@@funcadelic-${VERSION}/${name}`;
+  let symbolName = `@@funcadelic-${VERSION}/${name}/${uniqueTag++}`;
   let symbol = Symbol[symbolName] ? Symbol[symbolName] : Symbol[symbolName] = Symbol(symbolName);
 
   Class.for = function _for(value) {

--- a/src/typeclasses.js
+++ b/src/typeclasses.js
@@ -31,6 +31,7 @@ export function type(Class) {
     constructor.prototype[symbol] = methods;
   };
 
+  Class.symbolName = symbolName;
   Class.symbol = symbol;
 
   let properties = getOwnPropertyDescriptors(Class.prototype);

--- a/tests/funcadelic.test.js
+++ b/tests/funcadelic.test.js
@@ -16,14 +16,14 @@ describe('typeclasses', function() {
       Typeclass = type(MyClass);
     });
     it('attached typeclass to Symbol', () => {
-      expect(Symbol['@@funcadelic-0/MyClass']).toBe(Typeclass.symbol);
+      expect(Symbol[Typeclass.symbolName]).toBe(Typeclass.symbol);
     });
   });
 });
 
 describe('Functor', function() {
   it('attached typeclass to global Symbol', () => {
-    expect(typeof Symbol['@@funcadelic-0/Functor']).toBe('symbol');
+    expect(typeof Symbol[Functor.symbolName]).toBe('symbol');
   });
   it('maps objects', function() {
     expect(map((i) => i * 2, {one: 1, two: 2})).toEqual({one: 2, two: 4});


### PR DESCRIPTION
## What happened?

Turns out naming classes by numbers starting from 0 might not be a
good idea:

```
Unhandled JS Exception: invalid typeclass name: 0
```

So lets use the name & the uniqueTag together to avoid that

![image](https://user-images.githubusercontent.com/2072894/42400909-f4855d34-8138-11e8-9684-70426b2458de.png)
