### PR TITLE
Fix typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ a `flatMap`.
 ``` javascript
 let user = $.get('/');
 
-flatMap(user => $.get(`/wingdings/`${user.wingdingId}`))
+flatMap(user => $.get(`/wingdings/${user.wingdingId}`))
   .then(wingding => console.log(wingding));
 ```
 


### PR DESCRIPTION
Fixes a typo with an extra backtick in a template string.