### PR TITLE
Hide typeclass symbols from Safari Debugger

### DIFF
--- a/src/typeclasses.js
+++ b/src/typeclasses.js
@@ -1,6 +1,6 @@
 import invariant from 'invariant';
 
-const { keys, getOwnPropertyDescriptors } = Object;
+const { keys, getOwnPropertyDescriptors, defineProperty } = Object;
 
 invariant(getOwnPropertyDescriptors, `funcadelic.js requires Object.getOwnPropertyDescriptors. See https://github.com/cowboyd/funcadelic.js#compatibility`)
 invariant("name" in Function.prototype && "name" in (function x() {}), `funcadelic.js requires Function.name. See https://github.com/cowboyd/funcadelic.js#compatibility`);
@@ -28,7 +28,12 @@ export function type(Class) {
   };
 
   Class.instance = function(constructor, methods) {
-    constructor.prototype[symbol] = methods;
+    defineProperty(constructor.prototype, symbol, {
+      value: methods,
+      configurable: true,
+      // make the prototype non-enumerable to prevent it from showing in Safari debugger
+      enumerable: false
+    });
   };
 
   Class.symbolName = symbolName;

--- a/tests/funcadelic.test.js
+++ b/tests/funcadelic.test.js
@@ -18,6 +18,17 @@ describe('typeclasses', function() {
     it('attached typeclass to Symbol', () => {
       expect(Symbol[Typeclass.symbolName]).toBe(Typeclass.symbol);
     });
+    describe('instance registration', () => {
+      class MyOtherClass {}
+      beforeEach(() => {
+        Typeclass.instance(MyOtherClass, {});
+      });
+      it('makes typeclass instance on the prototype non-enumerable', () => {
+        expect(Object.getOwnPropertyDescriptor(MyOtherClass.prototype, Typeclass.symbol)).toMatchObject({
+          enumerable: false
+        })
+      });
+    });
   });
 });
 


### PR DESCRIPTION
This PR changes how type class instances are registered onto a class prototype to hide type symbol properties from Safari debugger. 

## Purpose

We  want to make sure that Funcadelic plays well with all JavaScript environments. Current implementation adds a lot of noice into the Safari Debugger because the properties are assigned onto the prototype which causes them to be enumerable.

## Method

Replace assignment with `Object.defineProperty` and set enumerable to false.

## Screenshots

### Before

<img width="1478" alt="screen shot 2019-02-15 at 11 06 20 am" src="https://user-images.githubusercontent.com/74687/52868891-72ff0a00-3112-11e9-9c07-cd0976ce6112.png">

### After

<img width="1484" alt="screen shot 2019-02-15 at 11 06 45 am" src="https://user-images.githubusercontent.com/74687/52868906-78f4eb00-3112-11e9-8412-69e5e0140bf2.png">

