### PR TITLE
Prepare 0.5.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.5.6] - 2019-02-16 [v0.5.5...v0.5.6](https://github.com/cowboyd/funcadelic.js/compare/v0.5.5...v0.5.6)
+
+### Fixed
+
+- Hide typeclass symbols from Safari Debugger https://github.com/cowboyd/funcadelic.js/pull/65
+
 ## [0.5.5] - 2018-07-10 [v0.5.4...v0.5.5](https://github.com/cowboyd/funcadelic.js/compare/v0.5.4...v0.5.5)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "funcadelic",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Functional Fundamentals are Fun!",
   "main": "dist/funcadelic.cjs.js",
   "module": "dist/funcadelic.es.js",


### PR DESCRIPTION
## [0.5.6] - 2019-02-16 [v0.5.5...v0.5.6](https://github.com/cowboyd/funcadelic.js/compare/v0.5.5...v0.5.6)

### Fixed

- Hide typeclass symbols from Safari Debugger https://github.com/cowboyd/funcadelic.js/pull/65