### PR TITLE
Add explicit name to typeclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.5.7] - 2019-03-27 [v0.5.6...v0.5.7](https://github.com/cowboyd/funcadelic.js/compare/v0.5.6...v0.5.7)
-
-### Fixed
+## Unreleased
 
 - Add explicit name to typeclasses to prevent Uglify from removing the name https://github.com/cowboyd/funcadelic.js/pull/68
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.5.7] - 2019-03-27 [v0.5.6...v0.5.7](https://github.com/cowboyd/funcadelic.js/compare/v0.5.6...v0.5.7)
+
+### Fixed
+
+- Add explicit name to typeclasses to prevent Uglify from removing the name https://github.com/cowboyd/funcadelic.js/pull/68
+
 ## [0.5.6] - 2019-02-16 [v0.5.5...v0.5.6](https://github.com/cowboyd/funcadelic.js/compare/v0.5.5...v0.5.6)
 
 ### Fixed

--- a/src/applicative.js
+++ b/src/applicative.js
@@ -11,6 +11,11 @@ export function curry(f) {
 }
 
 export const Applicative = type(class Applicative extends Functor {
+  
+  static get name() {
+    return 'Applicative'
+  }
+
   pure(Type, value) {
     return this(Type.prototype).pure(value);
   }

--- a/src/filterable.js
+++ b/src/filterable.js
@@ -1,6 +1,10 @@
 import { type } from './typeclasses';
 
 export const Filterable = type(class Filterable {
+  static get name() {
+    return 'Filterable'
+  }
+
   filter(fn, f) {
     return this(f).filter(fn, f);
   }

--- a/src/foldable.js
+++ b/src/foldable.js
@@ -1,6 +1,11 @@
 import { type } from './typeclasses';
 
 export const Foldable = type(class Foldable {
+
+  static get name() {
+    return 'Foldable'
+  }
+
   foldr(fn, initial, foldable) {
     let { foldr } = this(foldable);
     return foldr(fn, initial, foldable);

--- a/src/functor.js
+++ b/src/functor.js
@@ -1,6 +1,11 @@
 import { type } from './typeclasses';
 
 export const Functor = type(class Functor {
+
+  static get name() {
+    return 'Functor'
+  }
+  
   map(fn, f) {
     let { map } = this(f);
     return map(fn, f);

--- a/src/monad.js
+++ b/src/monad.js
@@ -2,6 +2,11 @@ import { type } from './typeclasses';
 import { Applicative } from './applicative';
 
 export const Monad = type(class Monad extends Applicative {
+
+  static get name() {
+    return 'Monad'
+  }
+  
   flatMap(fn, m) {
     return this(m).flatMap(fn, m);
   }

--- a/src/monoid.js
+++ b/src/monoid.js
@@ -4,6 +4,10 @@ import { map } from './functor';
 import { type } from './typeclasses';
 
 export const Monoid = type(class Monoid extends Semigroup {
+  static get name() {
+    return 'Monoid'
+  }
+
   reduce(M, values) {
     let empty = this(M.prototype).empty();
     return foldl((reduction, value) => append(reduction, value), empty, values);

--- a/src/semigroup.js
+++ b/src/semigroup.js
@@ -1,6 +1,11 @@
 import { type } from './typeclasses';
 
 export const Semigroup = type(class Semigroup {
+
+  static get name() {
+    return 'Semigroup'
+  }
+
   append(left, right) {
     let { append } = this(left);
     return append(left, right);


### PR DESCRIPTION
Uglify is an extra eager beaver by stripping off names from functions and classes. This breaks Funcadelic in environments where the developer doesn't have access to Uglify configurations. This is the case with [Razze](https://github.com/jaredpalmer/razzle) as was raised by https://github.com/microstates/microstates.js/issues/342

This PR adds an explicit name to each typeclass so Uglify doesn't strip the name off.