### PR TITLE
Shave a few bytes using tiny-invariant (Closes #67)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,13 +24,14 @@
     "dist"
   ],
   "dependencies": {
-    "invariant": "2.2.4"
+    "tiny-invariant": "^1.0.4"
   },
   "devDependencies": {
     "@babel/core": "7.2.0",
     "@babel/preset-env": "^7.2.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "23.6.0",
+    "babel-plugin-dev-expression": "^0.2.1",
     "benchmark": "^2.1.4",
     "cli-table2": "^0.2.0",
     "colors": "^1.2.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,7 @@ const resolve = require("rollup-plugin-node-resolve");
 const commonjs = require('rollup-plugin-commonjs');
 const replace = require('rollup-plugin-replace');
 
-let external = ["invariant"];
+let external = ["tiny-invariant"];
 
 let filesizePlugin = filesize();
 
@@ -18,9 +18,6 @@ module.exports = [
       format: "umd"
     },
     plugins: [
-      replace({
-        "process.env.NODE_ENV": JSON.stringify('production')
-      }),
       resolve(),
       commonjs(),
       babel({
@@ -36,7 +33,11 @@ module.exports = [
               modules: false
             }
           ]
-        ]
+        ],
+        plugins: [ 'dev-expression' ]
+      }),
+      replace({
+        "process.env.NODE_ENV": JSON.stringify('production')
       }),
       filesizePlugin
     ]
@@ -83,7 +84,11 @@ module.exports = [
               modules: false
             }
           ]
-        ]
+        ],
+        plugins: [ 'dev-expression' ]
+      }),
+      replace({
+        "process.env.NODE_ENV": JSON.stringify('production')
       }),
       filesizePlugin
     ]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -36,9 +36,6 @@ module.exports = [
         ],
         plugins: [ 'dev-expression' ]
       }),
-      replace({
-        "process.env.NODE_ENV": JSON.stringify('production')
-      }),
       filesizePlugin
     ]
   },
@@ -86,9 +83,6 @@ module.exports = [
           ]
         ],
         plugins: [ 'dev-expression' ]
-      }),
-      replace({
-        "process.env.NODE_ENV": JSON.stringify('production')
       }),
       filesizePlugin
     ]

--- a/src/typeclasses.js
+++ b/src/typeclasses.js
@@ -1,4 +1,4 @@
-import invariant from 'invariant';
+import invariant from 'tiny-invariant';
 
 const { keys, getOwnPropertyDescriptors, defineProperty } = Object;
 


### PR DESCRIPTION
The savings aren't huge, but every **bit** counts.

- Replace `invariant` with `tiny-invariant`
- Add `babel-plugin-dev-expression`, which makes the `invariant` checks easier to minify.

I excluded the CJS build, since it was targeting Node and the bytes are less important. 

**EDIT:**  How would you feel about adding some pre-minified ES & UMD builds?
```
Before:
┌────────────────────────────────────────┐
│                                        │
│   Destination: dist/funcadelic.es.js   │
│   Bundle Size:  17.64 KB               │
│   Minified Size:  10.43 KB             │
│   Gzipped Size:  2.84 KB               │
│                                        │
└────────────────────────────────────────┘
┌─────────────────────────────────────────┐
│                                         │
│   Destination: dist/funcadelic.umd.js   │
│   Bundle Size:  11.48 KB                │
│   Minified Size:  5.38 KB               │
│   Gzipped Size:  2.08 KB                │
│                                         │
└─────────────────────────────────────────┘

`tiny-invariant` + `babel-plugin-dev-expression`
┌────────────────────────────────────────┐
│                                        │
│   Destination: dist/funcadelic.es.js   │
│   Bundle Size:  17.65 KB               │
│   Minified Size:  10.44 KB             │
│   Gzipped Size:  2.85 KB               │
│                                        │
└────────────────────────────────────────┘
┌─────────────────────────────────────────┐
│                                         │
│   Destination: dist/funcadelic.umd.js   │
│   Bundle Size:  11.16 KB                │
│   Minified Size:  5.18 KB               │
│   Gzipped Size:  1.97 KB                │
│                                         │
└─────────────────────────────────────────┘

`tiny-invariant` + `babel-plugin-dev-expression` and replacing process.env.NODE_ENV='production'
┌────────────────────────────────────────┐
│                                        │
│   Destination: dist/funcadelic.es.js   │
│   Bundle Size:  17.47 KB               │
│   Minified Size:  10.23 KB             │
│   Gzipped Size:  2.79 KB               │
│                                        │
└────────────────────────────────────────┘
┌─────────────────────────────────────────┐
│                                         │
│   Destination: dist/funcadelic.umd.js   │
│   Bundle Size:  10.84 KB                │
│   Minified Size:  4.91 KB               │
│   Gzipped Size:  1.87 KB                │
│                                         │
└─────────────────────────────────────────┘
```